### PR TITLE
added calendar as default page and JS to switch to other tabs (blanks)

### DIFF
--- a/blank.html
+++ b/blank.html
@@ -5,5 +5,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blank</title>
   </head>
-  <body style="background-color: #f597ac"></body>
+  <body></body>
 </html>

--- a/blank.html
+++ b/blank.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blank</title>
+  </head>
+  <body style="background-color: #f597ac"></body>
+</html>

--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Calendar</title>
+    <link rel="stylesheet" href="./calendarstyle.css" />
+    <script src="index.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+    />
+  </head>
+  <body>
+    <div class="wrapper">
+      <header>
+        <p class="current-date">February 2025</p>
+        <div class="icons">
+          <span class="material-symbols-rounded">chevron_left</span>
+          <span class="material-symbols-rounded">chevron_right</span>
+        </div>
+      </header>
+      <div class="calendar">
+        <ul class="weeks">
+          <li>Mon</li>
+          <li>Tue</li>
+          <li>Wed</li>
+          <li>Thu</li>
+          <li>Fri</li>
+          <li>Sat</li>
+          <li>Sun</li>
+        </ul>
+        <ul class="days">
+          <li>27</li>
+          <li>28</li>
+          <li>29</li>
+          <li>30</li>
+          <li>31</li>
+          <li>1</li>
+          <li>2</li>
+          <li>3</li>
+          <li>4</li>
+          <li>5</li>
+          <li>6</li>
+          <li>7</li>
+          <li>8</li>
+          <li>9</li>
+          <li>10</li>
+          <li>11</li>
+          <li>12</li>
+          <li>13</li>
+          <li>14</li>
+          <li>15</li>
+          <li>16</li>
+          <li>17</li>
+          <li>18</li>
+          <li>19</li>
+          <li>20</li>
+          <li>21</li>
+          <li>22</li>
+          <li>23</li>
+          <li>24</li>
+          <li>25</li>
+          <li>26</li>
+          <li>27</li>
+          <li>28</li>
+          <li>1</li>
+          <li>2</li>
+        </ul>
+        </ul>
+        </ul>
+      </div>
+    </div>
+  </body>
+</html>

--- a/calendarstyle.css
+++ b/calendarstyle.css
@@ -1,0 +1,65 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: "Courier New", Courier, monospace;
+}
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #f597ac;
+}
+.wrapper {
+  width: 450px;
+  background: #f9becb;
+  border-radius: 10px;
+}
+.wrapper header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 25px 30px 10px;
+}
+header .current-date {
+  font-size: 16px;
+  font-weight: 1000;
+}
+header .icons span {
+  height: 38px;
+  width: 38px;
+  margin: 0 1px;
+  text-align: center;
+  line-height: 38px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+header .icons span:hover {
+  background: #f48aa2;
+}
+header .icons span:last-child {
+  margin-right: -10px;
+}
+.calendar {
+  padding: 20px;
+}
+.calendar ul {
+  display: flex;
+  list-style: none;
+  flex-wrap: wrap;
+  text-align: center;
+}
+.calendar .weeks li {
+  font-weight: 1000;
+}
+.calendar .days {
+  margin-bottom: 20px;
+}
+.calendar .days li {
+  cursor: pointer;
+  margin-top: 30px;
+}
+.calendar ul li {
+  width: calc(100% / 7);
+}

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
-    <script defer src="index.js"></script>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
@@ -39,7 +38,8 @@
     </div>
 
     <div class="main-content">
-      <iframe id="content-frame" src="calendar.html" frameborder="0"></iframe>
+      <iframe src="calendar.html" frameborder="0"></iframe>
     </div>
+    <script defer src="index.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
-    <script src="index.js"></script>
+    <script defer src="index.js"></script>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
@@ -12,30 +12,34 @@
       <header class="nav-header">Let's get organized</header>
       <ul class="nav-list">
         <li class="nav-li">
-          <a href="#" class="nav-link">
+          <a href="calendar.html" class="nav-link" data-tab="calendar">
             <img src="images/calendar.png" alt="Calendar" width="40" />
             <span>Calendar</span>
           </a>
         </li>
         <li class="nav-li">
-          <a href="#" class="nav-link">
+          <a href="blank.html" class="nav-link" data-tab="tasks">
             <img src="images/task.png" alt="Task" width="40" />
             <span>Tasks</span>
           </a>
         </li>
         <li class="nav-li">
-          <a href="#" class="nav-link">
+          <a href="blank.html" class="nav-link" data-tab="events">
             <img src="images/events2.png" alt="Events" width="40" />
             <span>Events</span>
           </a>
         </li>
         <li class="nav-li">
-          <a href="#" class="nav-link">
+          <a href="blank.html" class="nav-link" data-tab="completed">
             <img src="images/completed.png" alt="Completed Tasks" width="40" />
             <span>Completed Tasks</span>
           </a>
         </li>
       </ul>
+    </div>
+
+    <div class="main-content">
+      <iframe id="content-frame" src="calendar.html" frameborder="0"></iframe>
     </div>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 document.addEventListener("DOMContentLoaded", function () {
   const navLinks = document.querySelectorAll(".nav-link");
-  const iframe = document.getElementById("content-frame");
+  const iframe = document.getElementsByTagName("iframe")[0];
 
-  // Load calendar.html by default
+  if (!iframe) {
+    return;
+  }
+
+  // loading calendar as default
   iframe.src = "calendar.html";
 
   navLinks.forEach((link) => {
@@ -10,7 +14,7 @@ document.addEventListener("DOMContentLoaded", function () {
       event.preventDefault();
       const page = this.getAttribute("href");
 
-      // Change iframe src to the clicked page
+      // switching to other pages
       iframe.src = page;
     });
   });

--- a/index.js
+++ b/index.js
@@ -1,1 +1,17 @@
-console.log('test')
+document.addEventListener("DOMContentLoaded", function () {
+  const navLinks = document.querySelectorAll(".nav-link");
+  const iframe = document.getElementById("content-frame");
+
+  // Load calendar.html by default
+  iframe.src = "calendar.html";
+
+  navLinks.forEach((link) => {
+    link.addEventListener("click", function (event) {
+      event.preventDefault();
+      const page = this.getAttribute("href");
+
+      // Change iframe src to the clicked page
+      iframe.src = page;
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,4 +9,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC"
+  
 }

--- a/style.css
+++ b/style.css
@@ -3,11 +3,46 @@
   margin: 0;
   list-style: none;
   text-decoration: none;
+  box-sizing: border-box;
 }
+
 body {
   font-family: "Courier New", Courier, monospace;
   font-weight: bold;
+  display: flex; /* Allows navbar and content to be side by side */
+  height: 100vh; /* Ensure the full viewport height is used */
+  overflow: hidden; /* Prevents unwanted scrolling */
 }
+
+/* Sidebar (Navbar) */
+.navbar {
+  position: fixed;
+  left: 0;
+  width: 230px;
+  height: 100vh; /* Make navbar full height */
+  background: #914b5b;
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-header {
+  color: white;
+  font-size: 20px;
+  font-weight: bold;
+  text-align: center;
+  background: linear-gradient(135deg, #c26479, #914b5b);
+  padding: 20px 10px;
+  letter-spacing: 1px;
+  border-bottom: 3px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.nav-list {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+}
+
 .nav-link {
   display: flex;
   align-items: center;
@@ -16,30 +51,9 @@ body {
   padding: 20px;
   padding-left: 20px;
   color: white;
-  border-bottom: 1px solid #48252d; /* Only bottom border */
+  border-bottom: 1px solid #48252d;
 }
 
-.nav-header {
-  color: white;
-  font-size: 20px; /* Slightly bigger font for better readability */
-  font-weight: bold;
-  text-align: center;
-  background: linear-gradient(135deg, #c26479, #914b5b); /* Stylish gradient */
-  padding: 20px 10px;
-  letter-spacing: 1px;
-  border-bottom: 3px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
-  z-index: 2;
-}
-
-.navbar {
-  position: fixed;
-  left: 0;
-  width: 230px;
-  height: 1000%;
-  background: #914b5b;
-}
 .nav-link:hover {
   background: rgba(255, 255, 255, 0.2);
   padding-left: 25px;
@@ -49,4 +63,20 @@ body {
   background: rgba(255, 255, 255, 0.3);
   border-left: 5px solid white;
   padding-left: 25px;
+}
+
+/* Main Content */
+.main-content {
+  margin-left: 230px; /* Push content right to match navbar width */
+  width: calc(100% - 230px); /* Ensure iframe does not overlap the navbar */
+  height: 100vh;
+  display: flex;
+}
+
+/* Iframe (Calendar Page) */
+iframe {
+  width: 100%;
+  height: 100vh;
+  border: none;
+  display: block;
 }


### PR DESCRIPTION
Dear Nevena, 

The following changes are made:

- Set Calendar as the default page in the iframe.
- Started working on Calendar content structure.
- Fixed navbar positioning and ensured full-screen content.
- Updated JS to dynamically load pages inside the iframe.
- Added blank.html for non-calendar tabs.

Please check the changes, thank you!